### PR TITLE
Define static_assert to fix build failure on MacOS.

### DIFF
--- a/mzd_additional.c
+++ b/mzd_additional.c
@@ -18,6 +18,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if !defined(static_assert)
+#define static_assert _Static_assert
+#endif
+
 static const size_t mzd_local_t_size = (sizeof(mzd_local_t) + 0x1f) & ~0x1f;
 static_assert(((sizeof(mzd_local_t) + 0x1f) & ~0x1f) == 32, "sizeof mzd_local_t not supported");
 


### PR DESCRIPTION
The static_assert macro [http://en.cppreference.com/w/c/error/static_assert] (from C11) is not supported by GCC and Clang on Mac. However, C11 introduced the _Static_assert keyword, which we can use. 

This should solve the Travis failure we see on Mac in the OQS project [https://travis-ci.org/open-quantum-safe/liboqs/jobs/303173333]
