### PR TITLE
Fixes a memory leak on error.

### DIFF
--- a/picnic2_simulate.c.i
+++ b/picnic2_simulate.c.i
@@ -131,10 +131,10 @@ static int SIM_ONLINE(mzd_local_t* maskedKey, shares_t* mask_shares, randomTape_
   broadcast(mask_shares, msgs);
   msgsTranspose(msgs);
 
+Exit:
   free(unopened_msgs);
   freeShares(key_masks);
   freeShares(mask2_shares);
 
-Exit:
   return ret;
 }


### PR DESCRIPTION
Free variables before exit in case of error to avoid memory leak.