### PR TITLE
Fix explicit_bzero function.

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -98,7 +98,7 @@ static inline void explicit_bzero(void* a, size_t len) {
   SecureZeroMemory(a, len);
 #else
   volatile char* p = a;
-  for (; len; ++a, --len) {
+  for (; len; ++p, --len) {
     *p = 0;
   }
 #endif


### PR DESCRIPTION
The explicit_bzero function was only erasing the first char. This fixes the function.